### PR TITLE
fix: profile links

### DIFF
--- a/src/lib/Profile.ts
+++ b/src/lib/Profile.ts
@@ -42,6 +42,6 @@ export class Profile {
       return null;
     }
 
-    return nip19.noteEncode(this.id);
+    return nip19.npubEncode(this.id);
   }
 }


### PR DESCRIPTION
When clicking on accounts, it links to a profile that does not exist (e.g. for [this post](https://snort.social/e/note1yrtqla5dv8g4e58hlv7gjawgcju8fwzqdcl0q933j0kkpgvxjthsdqd937), here is [the link](https://snort.social/p/note187ln577k8mqza830604nu32jyxelje56yhp4ww0j07gcya8jmt6qh87ujr)), I fixed.
