### PR TITLE
patch: use pubkey instead of id

### DIFF
--- a/src/lib/Profile.ts
+++ b/src/lib/Profile.ts
@@ -42,6 +42,6 @@ export class Profile {
       return null;
     }
 
-    return nip19.npubEncode(this.id);
+    return nip19.npubEncode(this.pubkey);
   }
 }


### PR DESCRIPTION
Sorry for repeating myself.
It doesn't work unless pubkey instead of id. I didn't check enough.

I feel that the method name `nip19Id()` isn't appropriate in this case, should I change it?
