### PR TITLE
Bump nostr-tools to 1.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "linkify-plugin-hashtag": "^4.1.0",
         "linkify-plugin-mention": "^4.1.0",
         "linkifyjs": "^4.1.0",
-        "nostr-tools": "^1.2.1",
+        "nostr-tools": "1.4.2",
         "sanitize-html": "^2.9.0",
         "svelte-local-storage-store": "^0.4.0",
         "svelte-modals": "^1.2.1"
@@ -2682,9 +2682,9 @@
       }
     },
     "node_modules/nostr-tools": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-1.4.0.tgz",
-      "integrity": "sha512-8aiFjGuQEKtxHymNTlNVqPG7q6//cVRTMuZlVLgnDj7VbNzFeurArWJeYC1eHaCrwz554KmhLY9dx0bc2ug6Gw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-1.4.2.tgz",
+      "integrity": "sha512-JKAEbJI89VkGYWBB27PBhD4WPfjnpAtVIBaDTA2YN97BkiyzigTiMGycsxpejagajYr+uTNMMWED5PMFTmtYJA==",
       "dependencies": {
         "@noble/hashes": "1.0.0",
         "@noble/secp256k1": "^1.7.1",
@@ -5855,9 +5855,9 @@
       "dev": true
     },
     "nostr-tools": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-1.4.0.tgz",
-      "integrity": "sha512-8aiFjGuQEKtxHymNTlNVqPG7q6//cVRTMuZlVLgnDj7VbNzFeurArWJeYC1eHaCrwz554KmhLY9dx0bc2ug6Gw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-1.4.2.tgz",
+      "integrity": "sha512-JKAEbJI89VkGYWBB27PBhD4WPfjnpAtVIBaDTA2YN97BkiyzigTiMGycsxpejagajYr+uTNMMWED5PMFTmtYJA==",
       "requires": {
         "@noble/hashes": "1.0.0",
         "@noble/secp256k1": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "linkify-plugin-hashtag": "^4.1.0",
     "linkify-plugin-mention": "^4.1.0",
     "linkifyjs": "^4.1.0",
-    "nostr-tools": "^1.2.1",
+    "nostr-tools": "1.4.2",
     "sanitize-html": "^2.9.0",
     "svelte-local-storage-store": "^0.4.0",
     "svelte-modals": "^1.2.1"


### PR DESCRIPTION
Fixed to version 1.4.2 because nostr-tools 1.5.0 seems unstable.